### PR TITLE
Fix special token bug for llama models

### DIFF
--- a/src/uie_collator.py
+++ b/src/uie_collator.py
@@ -149,8 +149,8 @@ class DataCollatorForUIE:
             task_input = self.tokenizer.bos_token + instruction
             label = label + self.tokenizer.eos_token
 
-            tokenized_input = self.tokenizer(task_input)["input_ids"]
-            tokenized_label = self.tokenizer(label)["input_ids"]
+            tokenized_input = self.tokenizer(task_input, add_special_tokens=False)["input_ids"]
+            tokenized_label = self.tokenizer(label, add_special_tokens=False)["input_ids"]
 
             # (input) for inference, (input + label) for training
             if instance['subset'] in ['dev', 'test']:


### PR DESCRIPTION
Since the llama(1&2) tokenizer defaults to using `"add_bos_token": true` , we need to avoid duplicate `<s>` in the prefix input and undesired `<s>` in the prefix output(label).